### PR TITLE
.NET 2.0 support

### DIFF
--- a/Nustache.Core/Nustache.Core.csproj
+++ b/Nustache.Core/Nustache.Core.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Nustache.Core</RootNamespace>
     <AssemblyName>Nustache.Core</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -32,15 +32,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/Nustache.Core/Render.cs
+++ b/Nustache.Core/Render.cs
@@ -10,7 +10,7 @@ namespace Nustache.Core
             return StringToString(template, data, null);
         }
 
-        public static string StringToString(string template, object data, Func<string, Template> templateLocator)
+        public static string StringToString(string template, object data, TemplateLocator templateLocator)
         {
             var reader = new StringReader(template);
             var writer = new StringWriter();
@@ -44,7 +44,7 @@ namespace Nustache.Core
             }
         }
 
-        public static void Template(TextReader reader, object data, TextWriter writer, Func<string, Template> templateLocator)
+        public static void Template(TextReader reader, object data, TextWriter writer, TemplateLocator templateLocator)
         {
             var template = new Template();
             template.Load(reader);

--- a/Nustache.Core/RenderContext.cs
+++ b/Nustache.Core/RenderContext.cs
@@ -5,16 +5,18 @@ using System.IO;
 
 namespace Nustache.Core
 {
+    public delegate Template TemplateLocator(string name);
+
     public class RenderContext
     {
         private const int IncludeLimit = 1024;
         private readonly Stack<Section> _sectionStack = new Stack<Section>();
         private readonly Stack<object> _dataStack = new Stack<object>();
         private readonly TextWriter _writer;
-        private readonly Func<string, Template> _templateLocator;
+        private readonly TemplateLocator _templateLocator;
         private int _includeLevel;
 
-        public RenderContext(Section section, object data, TextWriter writer, Func<string, Template> templateLocator)
+        public RenderContext(Section section, object data, TextWriter writer, TemplateLocator templateLocator)
         {
             _sectionStack.Push(section);
             _dataStack.Push(data);

--- a/Nustache.Core/Template.cs
+++ b/Nustache.Core/Template.cs
@@ -40,7 +40,7 @@ namespace Nustache.Core
         /// <remarks>
         /// The <paramref name="writer" /> is flushed, but not closed or disposed.
         /// </remarks>
-        public void Render(object data, TextWriter writer, Func<string, Template> templateLocator)
+        public void Render(object data, TextWriter writer, TemplateLocator templateLocator)
         {
             var context = new RenderContext(this, data, writer, templateLocator);
 


### PR DESCRIPTION
Hi Jason,

I'm using your excellent Nustache framework in a .NET project. Thanks for creating it!

We need to support .NET 2.0. It appears the only thing holding us back from using Nustache.Core was the use of Func<string, Template> which is easily replaced with a delegate. I've done so in this branch (rather messily), so I'd invite you to consider integrating something similar upstream... your call!

Thanks again.

Adam Ernst
