### PR TITLE
Strip out new lines after non-variable markers.

### DIFF
--- a/Nustache.Core.Tests/Describe_Scanner.cs
+++ b/Nustache.Core.Tests/Describe_Scanner.cs
@@ -95,5 +95,18 @@ namespace Nustache.Core.Tests
             parts.IsEqualTo(new LiteralText("before"),
                             new LiteralText("after"));
         }
+
+        [Test]
+        public void It_strips_out_new_lines_after_non_variable_markers()
+        {
+            var scanner = new Scanner();
+
+            var parts = scanner.Scan("before\r\n{{#foo}} \r\n{{/foo}}\t\r\n\r\nafter");
+
+            parts.IsEqualTo(new LiteralText("before\r\n"),
+                            new Block("foo"),
+                            new EndSection("foo"),
+                            new LiteralText("\r\nafter"));
+        }
     }
 }


### PR DESCRIPTION
Nice to get rid of the newlines, especially with blocks that don't get rendered.

(No idea why `\G` works in that regex when `^` and `\A` don't...)
