### PR TITLE
Case insensitive tag lookup

### DIFF
--- a/Nustache.Core.Tests/Describe_ValueGetter.cs
+++ b/Nustache.Core.Tests/Describe_ValueGetter.cs
@@ -25,6 +25,14 @@ namespace Nustache.Core.Tests
         }
 
         [Test]
+        public void It_gets_case_insensitive_field_values()
+        {
+            ReadWriteInts target = new ReadWriteInts();
+            target.IntField = 123;
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "intfield"));
+        }
+
+        [Test]
         public void It_gets_property_values()
         {
             ReadWriteInts target = new ReadWriteInts();
@@ -33,11 +41,27 @@ namespace Nustache.Core.Tests
         }
 
         [Test]
+        public void It_gets_case_insensitive_property_values()
+        {
+            ReadWriteInts target = new ReadWriteInts();
+            target.IntField = 123;
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "intproperty"));
+        }
+
+        [Test]
         public void It_gets_method_values()
         {
             ReadWriteInts target = new ReadWriteInts();
             target.IntField = 123;
             Assert.AreEqual(123, ValueGetter.GetValue(target, "IntMethod"));
+        }
+
+        [Test]
+        public void It_gets_case_insensitive_method_values()
+        {
+            ReadWriteInts target = new ReadWriteInts();
+            target.IntField = 123;
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "intmethod"));
         }
 
         [Test]
@@ -88,6 +112,16 @@ namespace Nustache.Core.Tests
             dt.Rows.Add(new object[] { 123 });
             DataRowView target = dt.DefaultView[0];
             Assert.AreEqual(123, ValueGetter.GetValue(target, "IntColumn"));
+        }
+
+        [Test]
+        public void It_gets_case_insensitive_DataRowView_values()
+        {
+            DataTable dt = new DataTable();
+            dt.Columns.Add("IntColumn", typeof(int));
+            dt.Rows.Add(new object[] { 123 });
+            DataRowView target = dt.DefaultView[0];
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "intcolumn"));
         }
 
         [Test]

--- a/Nustache.Core/ValueGetter.cs
+++ b/Nustache.Core/ValueGetter.cs
@@ -40,7 +40,8 @@ namespace Nustache.Core
 
         #region Constants for derived classes that use reflection
 
-        protected const BindingFlags DefaultBindingFlags = BindingFlags.Public | BindingFlags.Instance;
+        protected const BindingFlags DefaultBindingFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase;
+        protected const StringComparison DefaultNameComparison = StringComparison.CurrentCultureIgnoreCase;
 
         #endregion
     }
@@ -105,7 +106,7 @@ namespace Nustache.Core
 
                 foreach (PropertyDescriptor property in properties)
                 {
-                    if (property.Name ==  name)
+                    if (String.Equals(property.Name, name, DefaultNameComparison))
                     {
                         return new PropertyDescriptorValueGetter(target, property);
                     }


### PR DESCRIPTION
Here is a patch (incl tests) to make Nustache support case-insensitive tag lookups for properties, fields and methods, to bring it inline with [Mustache's case-insensitive support](https://github.com/neocotic/template/issues/50).

Note XML is still case-sensitive for now; it seems there is no easy way to do case-insensitive XPath queries in .NET without writing your own XPath extensions (see http://blogs.msdn.com/b/shjin/archive/2005/07/22/442025.aspx).
