### PR TITLE
Added variables evaluation && perf tweak

### DIFF
--- a/Nustache.Core.Tests/Describe_Template_Render.cs
+++ b/Nustache.Core.Tests/Describe_Template_Render.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using NUnit.Framework;
 
 namespace Nustache.Core.Tests
@@ -79,14 +80,14 @@ namespace Nustache.Core.Tests
         [Test]
         public void It_renders_sections_mapped_to_non_empty_collections()
         {
-            var result = Render.StringToString("before{{#foo}}FOO{{/foo}}after", new { foo = new [] { 1 } });
+            var result = Render.StringToString("before{{#foo}}FOO{{/foo}}after", new { foo = new[] { 1 } });
             Assert.AreEqual("beforeFOOafter", result);
         }
 
         [Test]
         public void It_renders_sections_mapped_to_non_empty_collections_for_each_item_in_the_collection()
         {
-            var result = Render.StringToString("before{{#foo}}FOO{{/foo}}after", new { foo = new [] { 1, 2, 3 } });
+            var result = Render.StringToString("before{{#foo}}FOO{{/foo}}after", new { foo = new[] { 1, 2, 3 } });
             Assert.AreEqual("beforeFOOFOOFOOafter", result);
         }
 
@@ -109,7 +110,7 @@ namespace Nustache.Core.Tests
         {
             var result = Render.StringToString(
                 "before{{#foo}}{{bar}}{{/foo}}after",
-                new { foo = new [] { new { bar = 1 }, new { bar = 2 }, new { bar = 3 } } });
+                new { foo = new[] { new { bar = 1 }, new { bar = 2 }, new { bar = 3 } } });
             Assert.AreEqual("before123after", result);
         }
 
@@ -190,6 +191,20 @@ namespace Nustache.Core.Tests
                 new { bar = "baz" });
 
             Assert.AreEqual("beforeINSIDEafter", result);
+        }
+
+        [Test]
+        public void It_renders_templates_mapped_to_evaluations()
+        {
+            var result = Render.StringToString(
+                "{{#birthday.month.$eq(3)}}{{name}} was born in March{{/birthday.month.$eq(3)}}",
+                new
+                {
+                    birthday = new DateTime(1974, 3, 12),
+                    name = "Andrea"
+                });
+            
+            Assert.AreEqual("Andrea was born in March", result);
         }
     }
 }

--- a/Nustache.Core.Tests/Describe_ValueGetter.cs
+++ b/Nustache.Core.Tests/Describe_ValueGetter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Xml;
@@ -151,6 +152,61 @@ namespace Nustache.Core.Tests
             Assert.AreEqual(2, elements.Count);
             Assert.AreEqual("text1", elements[0].InnerText);
             Assert.AreEqual("text2", elements[1].InnerText);
+        }
+
+        [Test]
+        public void It_gets_gt_value()
+        {
+            var t = ValueGetter.GetValue(1901, "$gt(1900)");
+            var f = ValueGetter.GetValue(1899, "$gt(1900)");
+            Assert.AreEqual(true, t);
+            Assert.AreEqual(false, f);
+        }
+
+        [Test]
+        public void It_gets_lt_value()
+        {
+            var t = ValueGetter.GetValue(1899, "$lt(1900)");
+            var f = ValueGetter.GetValue(1901, "$lt(1900)");
+            Assert.AreEqual(true, t);
+            Assert.AreEqual(false, f);
+        }
+
+        [Test]
+        public void It_gets_gte_value()
+        {
+            var t = ValueGetter.GetValue(1900, "$gte(1900)");
+            var f = ValueGetter.GetValue(1899, "$gte(1900)");
+            Assert.AreEqual(true, t);
+            Assert.AreEqual(false, f);
+        }
+
+        [Test]
+        public void It_gets_lte_value()
+        {
+            var t = ValueGetter.GetValue(1900, "$lte(1900)");
+            var f = ValueGetter.GetValue(1901, "$lte(1900)");
+            Assert.AreEqual(true, t);
+            Assert.AreEqual(false, f);
+        }
+
+        
+        [Test]
+        public void It_gets_eq_value()
+        {
+            var t = ValueGetter.GetValue(1900, "$eq(1900)");
+            var f = ValueGetter.GetValue(1901, "$eq(1900)");
+            Assert.AreEqual(true, t);
+            Assert.AreEqual(false, f);
+        }
+
+        [Test]
+        public void It_gets_ne_value()
+        {
+            var t = ValueGetter.GetValue(1901, "$ne(1900)");
+            var f = ValueGetter.GetValue(1900, "$ne(1900)");
+            Assert.AreEqual(true, t);
+            Assert.AreEqual(false, f);
         }
 
         public class ReadWriteInts

--- a/Nustache.Core/Block.cs
+++ b/Nustache.Core/Block.cs
@@ -10,15 +10,20 @@ namespace Nustache.Core
 
         public override void Render(RenderContext context)
         {
-            var lambda = context.GetValue(Name) as Lambda;
-            if (lambda != null)
-            {
-                context.Write(lambda(InnerSource()).ToString());
-                return;
-            }
-
+            bool checkLambda = true;
             foreach (var value in context.GetValues(Name))
             {
+                if (checkLambda)
+                {
+                    checkLambda = false;
+                    var lambda = value as Lambda;
+                    if (lambda != null)
+                    {
+                        context.Write(lambda(InnerSource()).ToString());
+                        return;
+                    }
+                }
+                
                 context.Push(this, value);
 
                 base.Render(context);


### PR DESCRIPTION
I've added $gt, $lt, $eq, $ne, $gte, $lte to value getters so now it's possible to enable conditional rendering on data values without polluting the model.

Changed the lambda evaluation because GetValue was called twice (once outside the foreach, one inside).