### PR TITLE
Preserving undefined variables

### DIFF
--- a/Nustache.Core.Tests/Describe_Block.cs
+++ b/Nustache.Core.Tests/Describe_Block.cs
@@ -19,7 +19,7 @@ namespace Nustache.Core.Tests
         {
             var a = new Block("a", new LiteralText("b"));
             var writer = new StringWriter();
-            var context = new RenderContext(null, new { a = true }, writer, null);
+            var context = new RenderContext(null, new { a = true }, writer, null, Options.Defaults());
 
             a.Render(context);
 
@@ -31,7 +31,7 @@ namespace Nustache.Core.Tests
         {
             var a = new Block("a", new LiteralText("b"));
             var writer = new StringWriter();
-            var context = new RenderContext(null, new { a = "" }, writer, null);
+            var context = new RenderContext(null, new { a = "" }, writer, null, Options.Defaults());
 
             a.Render(context);
 
@@ -43,7 +43,7 @@ namespace Nustache.Core.Tests
         {
             var a = new Block("a", new LiteralText("b"));
             var writer = new StringWriter();
-            var context = new RenderContext(null, new { a = new [] { 1, 2, 3 } }, writer, null);
+            var context = new RenderContext(null, new { a = new[] { 1, 2, 3 } }, writer, null, Options.Defaults());
 
             a.Render(context);
 
@@ -55,7 +55,7 @@ namespace Nustache.Core.Tests
         {
             var a = new Block("a.b", new LiteralText("c"));
             var writer = new StringWriter();
-            var context = new RenderContext(null, new { a = new { b = new[] { 1, 2, 3 } } }, writer, null);
+            var context = new RenderContext(null, new { a = new { b = new[] { 1, 2, 3 } } }, writer, null, Options.Defaults());
 
             a.Render(context);
 
@@ -71,7 +71,8 @@ namespace Nustache.Core.Tests
                 null,
                 new { a = new Dictionary<string, int> { { "b", 1 }, { "c", 2 }, { "d", 3 } } },
                 writer,
-                null);
+                null,
+                Options.Defaults());
 
             a.Render(context);
 

--- a/Nustache.Core.Tests/Describe_EndSection.cs
+++ b/Nustache.Core.Tests/Describe_EndSection.cs
@@ -18,7 +18,7 @@ namespace Nustache.Core.Tests
         {
             var a = new EndSection("a");
             var writer = new StringWriter();
-            var context = new RenderContext(null, null, writer, null);
+            var context = new RenderContext(null, null, writer, null, Options.Defaults());
 
             a.Render(context);
 

--- a/Nustache.Core.Tests/Describe_InvertedBlock.cs
+++ b/Nustache.Core.Tests/Describe_InvertedBlock.cs
@@ -62,7 +62,7 @@ namespace Nustache.Core.Tests
             var inverted = new InvertedBlock("a", text);
 
             using (var writer = new StringWriter()) {
-                var context = new RenderContext(null, new { a = value }, writer, null);
+                var context = new RenderContext(null, new { a = value }, writer, null, Options.Defaults());
 
                 inverted.Render(context);
 

--- a/Nustache.Core.Tests/Describe_LiteralText.cs
+++ b/Nustache.Core.Tests/Describe_LiteralText.cs
@@ -18,7 +18,7 @@ namespace Nustache.Core.Tests
         {
             var a = new LiteralText("a");
             var writer = new StringWriter();
-            var context = new RenderContext(null, null, writer, null);
+            var context = new RenderContext(null, null, writer, null, Options.Defaults());
 
             a.Render(context);
 

--- a/Nustache.Core.Tests/Describe_Render.cs
+++ b/Nustache.Core.Tests/Describe_Render.cs
@@ -33,6 +33,17 @@ namespace Nustache.Core.Tests
         }
 
         [Test]
+        public void It_can_render_strings_to_files_with_options()
+        {
+            var outputPath = CreateEmptyFile();
+            var options = Options.Defaults();
+
+            Render.StringToFile("{{foo}}", new { foo = "bar" }, outputPath, options);
+
+            Assert.AreEqual("bar", File.ReadAllText(outputPath));
+        }
+
+        [Test]
         public void It_can_render_files_to_strings()
         {
             var templatePath = CreateFile("{{foo}}");

--- a/Nustache.Core.Tests/Describe_TemplateDefinition.cs
+++ b/Nustache.Core.Tests/Describe_TemplateDefinition.cs
@@ -19,7 +19,7 @@ namespace Nustache.Core.Tests
             var a = new TemplateDefinition("a");
             a.Load(new Part[] { new LiteralText("b") });
             var writer = new StringWriter();
-            var context = new RenderContext(new Template(), null, writer, null);
+            var context = new RenderContext(new Template(), null, writer, null, Options.Defaults());
 
             a.Render(context);
 

--- a/Nustache.Core.Tests/Describe_TemplateInclude.cs
+++ b/Nustache.Core.Tests/Describe_TemplateInclude.cs
@@ -20,7 +20,7 @@ namespace Nustache.Core.Tests
             var template = new Template();
             template.Load(new Part[] { new LiteralText("b") });
             var writer = new StringWriter();
-            var context = new RenderContext(new Template(), null, writer, name => template);
+            var context = new RenderContext(new Template(), null, writer, name => template, Options.Defaults());
 
             a.Render(context);
 

--- a/Nustache.Core.Tests/Describe_Template_Render.cs
+++ b/Nustache.Core.Tests/Describe_Template_Render.cs
@@ -14,17 +14,33 @@ namespace Nustache.Core.Tests
         }
 
         [Test]
-        public void It_preserves_undefined_variables_with_empty_strings_when_there_is_no_data()
+        public void It_preserves_undefined_variables_with_empty_strings_when_there_is_no_data_and_options_set_to_preserve_undefined_variables()
         {
-            var result = Render.StringToString("before{{foo}}after", null);
+            var options = new Options { PreserveUndefinedVariables = true };
+            var result = Render.StringToString("before{{foo}}after", null, options);
             Assert.AreEqual("before{{foo}}after", result);
         }
 
         [Test]
-        public void It_preserves_undefined_variables_with_empty_strings_when_there_is_data()
+        public void It_preserves_undefined_variables_with_empty_strings_when_there_is_data_and_options_set_to_preserve_undefined_variables()
+        {
+            var options = new Options { PreserveUndefinedVariables = true };
+            var result = Render.StringToString("before{{foo}}after", new { bar = "baz" }, options);
+            Assert.AreEqual("before{{foo}}after", result);
+        }
+
+        [Test]
+        public void It_removes_undefined_variables_with_empty_strings_when_there_is_no_data_and_options_set_to_defaults()
+        {
+            var result = Render.StringToString("before{{foo}}after", null);
+            Assert.AreEqual("beforeafter", result);
+        }
+
+        [Test]
+        public void It_premoves_undefined_variables_with_empty_strings_when_there_is_data_and_options_set_to_defaults()
         {
             var result = Render.StringToString("before{{foo}}after", new { bar = "baz" });
-            Assert.AreEqual("before{{foo}}after", result);
+            Assert.AreEqual("beforeafter", result);
         }
 
         [Test]
@@ -128,7 +144,7 @@ namespace Nustache.Core.Tests
             var result = Render.StringToString(
                 "{{#foo}}{{bar}}{{/foo}}",
                 new { foo = new { bar = (string)null }, bar = "baz" });
-            Assert.AreEqual("{{bar}}", result);
+            Assert.AreEqual("", result);
         }
 
         [Test]

--- a/Nustache.Core.Tests/Describe_VariableReference.cs
+++ b/Nustache.Core.Tests/Describe_VariableReference.cs
@@ -18,7 +18,7 @@ namespace Nustache.Core.Tests
         {
             var a = new VariableReference("a");
             var writer = new StringWriter();
-            var context = new RenderContext(null, new { a = "b" }, writer, null);
+            var context = new RenderContext(null, new { a = "b" }, writer, null, Options.Defaults());
 
             a.Render(context);
 
@@ -30,7 +30,7 @@ namespace Nustache.Core.Tests
         {
             var a = new VariableReference("a.b");
             var writer = new StringWriter();
-            var context = new RenderContext(null, new { a = new { b = "c" } }, writer, null);
+            var context = new RenderContext(null, new { a = new { b = "c" } }, writer, null, Options.Defaults());
 
             a.Render(context);
 

--- a/Nustache.Core/Nustache.Core.csproj
+++ b/Nustache.Core/Nustache.Core.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="Encoders.cs" />
     <Compile Include="FileSystemTemplateLocator.cs" />
+    <Compile Include="Options.cs" />
     <Compile Include="Section.cs" />
     <Compile Include="TemplateDefinition.cs" />
     <Compile Include="Render.cs" />

--- a/Nustache.Core/Render.cs
+++ b/Nustache.Core/Render.cs
@@ -4,60 +4,94 @@ namespace Nustache.Core
 {
     public static class Render
     {
-        public static string StringToString(string template, object data)
+        public static void FileToFile(string templatePath, object data, string outputPath)
         {
-            return StringToString(template, data, null);
+            FileToFile(templatePath, data, outputPath, null);
         }
 
-        public static string StringToString(string template, object data, TemplateLocator templateLocator)
+        public static void FileToFile(string templatePath, object data, string outputPath, Options options)
         {
-            var reader = new StringReader(template);
-            var writer = new StringWriter();
-            Template(reader, data, writer, templateLocator);
-            return writer.GetStringBuilder().ToString();
+            var reader = new StringReader(File.ReadAllText(templatePath));
+            FileSystemTemplateLocator templateLocator = GetTemplateLocator(templatePath);
+            using (StreamWriter writer = File.CreateText(outputPath))
+            {
+                Template(reader, data, writer, templateLocator.GetTemplate, options);
+            }
         }
 
         public static string FileToString(string templatePath, object data)
         {
-            var template = File.ReadAllText(templatePath);
-            var templateLocator = GetTemplateLocator(templatePath);
+            string template = File.ReadAllText(templatePath);
+            FileSystemTemplateLocator templateLocator = GetTemplateLocator(templatePath);
             return StringToString(template, data, templateLocator.GetTemplate);
         }
 
         public static void StringToFile(string template, object data, string outputPath)
         {
-            StringToFile(template, data, outputPath, null);
+            StringToFile(template, data, outputPath, null, null);
         }
 
-        public static void StringToFile(string template, object data, string outputPath, TemplateLocator templateLocator)
+        public static void StringToFile(string template, object data, string outputPath, Options options)
+        {
+            StringToFile(template, data, outputPath, null, options);
+        }
+
+        public static void StringToFile(
+            string template, object data, string outputPath, TemplateLocator templateLocator)
+        {
+            StringToFile(template, data, outputPath, templateLocator, null);
+        }
+
+        public static void StringToFile(
+            string template, object data, string outputPath, TemplateLocator templateLocator, Options options)
         {
             var reader = new StringReader(template);
-            using (var writer = File.CreateText(outputPath))
+            using (StreamWriter writer = File.CreateText(outputPath))
             {
-                Template(reader, data, writer, templateLocator);
+                Template(reader, data, writer, templateLocator, options);
             }
         }
 
-        public static void FileToFile(string templatePath, object data, string outputPath)
+        public static string StringToString(string template, object data)
         {
-            var reader = new StringReader(File.ReadAllText(templatePath));
-            var templateLocator = GetTemplateLocator(templatePath);
-            using (var writer = File.CreateText(outputPath))
-            {
-                Template(reader, data, writer, templateLocator.GetTemplate);
-            }
+            return StringToString(template, data, null, null);
+        }
+
+        public static string StringToString(string template, object data, Options options)
+        {
+            return StringToString(template, data, null, options);
+        }
+
+        public static string StringToString(string template, object data, TemplateLocator templateLocator)
+        {
+            return StringToString(template, data, templateLocator, null);
+        }
+
+        public static string StringToString(
+            string template, object data, TemplateLocator templateLocator, Options options)
+        {
+            var reader = new StringReader(template);
+            var writer = new StringWriter();
+            Template(reader, data, writer, templateLocator, options);
+            return writer.GetStringBuilder().ToString();
         }
 
         public static void Template(TextReader reader, object data, TextWriter writer)
         {
-            Template(reader, data, writer, null);
+            Template(reader, data, writer, null, null);
         }
 
-        public static void Template(TextReader reader, object data, TextWriter writer, TemplateLocator templateLocator)
+        public static void Template(
+            TextReader reader, object data, TextWriter writer, TemplateLocator templateLocator, Options options)
         {
+            if (options == null)
+            {
+                options = Options.Defaults();
+            }
+
             var template = new Template();
             template.Load(reader);
-            template.Render(data, writer, templateLocator);
+            template.Render(data, writer, templateLocator, options);
         }
 
         private static FileSystemTemplateLocator GetTemplateLocator(string templatePath)

--- a/Nustache.Core/RenderContext.cs
+++ b/Nustache.Core/RenderContext.cs
@@ -11,20 +11,34 @@ namespace Nustache.Core
 
     public class RenderContext
     {
-        private const int IncludeLimit = 1024;
+        private const int INCLUDE_LIMIT = 1024;
+
         private readonly Stack<Section> _sectionStack = new Stack<Section>();
+
         private readonly Stack<object> _dataStack = new Stack<object>();
+
         private readonly TextWriter _writer;
+
         private readonly TemplateLocator _templateLocator;
+
         private int _includeLevel;
 
-        public RenderContext(Section section, object data, TextWriter writer, TemplateLocator templateLocator)
+        public Options CurrentOptions { get; set; }
+
+        public RenderContext(
+            Section section, 
+            object data, 
+            TextWriter writer, 
+            TemplateLocator templateLocator, 
+            Options options)
         {
             _sectionStack.Push(section);
             _dataStack.Push(data);
             _writer = writer;
             _templateLocator = templateLocator;
             _includeLevel = 0;
+
+            CurrentOptions = options;
         }
 
         public object GetValue(string path)
@@ -113,10 +127,10 @@ namespace Nustache.Core
 
         public void Include(string templateName)
         {
-            if (_includeLevel >= IncludeLimit)
+            if (_includeLevel >= INCLUDE_LIMIT)
             {
                 throw new NustacheException(
-                    string.Format("You have reached the include limit of {0}. Are you trying to render infinitely recursive templates or data?", IncludeLimit));
+                    string.Format("You have reached the include limit of {0}. Are you trying to render infinitely recursive templates or data?", INCLUDE_LIMIT));
             }
 
             _includeLevel++;

--- a/Nustache.Core/Template.cs
+++ b/Nustache.Core/Template.cs
@@ -42,12 +42,13 @@ namespace Nustache.Core
         /// <param name="data">The data to use to render the template.</param>
         /// <param name="writer">The object to write the output to.</param>
         /// <param name="templateLocator">The delegate to use to locate templates for inclusion.</param>
+        /// <param name="options">The options defining the behaviour of the renderer.</param>
         /// <remarks>
         /// The <paramref name="writer" /> is flushed, but not closed or disposed.
         /// </remarks>
-        public void Render(object data, TextWriter writer, TemplateLocator templateLocator)
+        public void Render(object data, TextWriter writer, TemplateLocator templateLocator, Options options)
         {
-            var context = new RenderContext(this, data, writer, templateLocator);
+            var context = new RenderContext(this, data, writer, templateLocator, options);
 
             Render(context);
 

--- a/Nustache.Core/VariableReference.cs
+++ b/Nustache.Core/VariableReference.cs
@@ -41,8 +41,10 @@ namespace Nustache.Core
             }
             else
             {
-                // Leave tag in for integration testing
-                context.Write(Source());
+                if (context.CurrentOptions.PreserveUndefinedVariables)
+                {
+                    context.Write(Source());
+                }
             }
         }
 

--- a/Nustache.Mvc3/NustacheView.cs
+++ b/Nustache.Mvc3/NustacheView.cs
@@ -56,11 +56,12 @@ namespace Nustache.Mvc
                             }
 
                             return FindPartial(name);
-                        });
+                        },
+                    Options.Defaults());
             }
             else
             {
-                GetTemplate().Render(data, writer, FindPartial);
+                GetTemplate().Render(data, writer, FindPartial, Options.Defaults());
             }
         }
 


### PR DESCRIPTION
Hi Jason,

We've been using Nustache for a while now for constructing email bodies (and frankly love it) however to ensure that our templates are being properly populated by data we wanted to create a series of integration tests checking the replacement.

The issue we were having was that Nustache removes any undefined variables if they do not have matching data.  This is great for production; but in a development environment it would be useful to us to see the variables that are not being defined.

Please see the attached commits for the implementation of this; I've tried to ensure existing functionality remains untouched; the main changes are:
- New Options object with a PreserveUndefinedVariables property and a Defaults static method
- Render has a few new overloads (So as to preserve existing functionality) for passing in an Objects instance
- VariableReference.Render now checks this object on the context
  - If PreserveUndefinedVariables is true it leaves the undefined variable in the resulting string
  - Otherwise (and by default) the undefined variable is left in.

This is fairly specific to a series of integration tests we'd like to run; however I thought you may want a pull request all the same.

Bear in mind this is also my first (ever) pull request so any advice on making it better would be appreciated.

Cheers,
Luke
