### PR TITLE
Updated XML handling a bit

### DIFF
--- a/Nustache.Core.Tests/Describe_ValueGetter.cs
+++ b/Nustache.Core.Tests/Describe_ValueGetter.cs
@@ -133,13 +133,12 @@ namespace Nustache.Core.Tests
         }
 
         [Test]
-        public void It_gets_XmlNode_single_child_element_values_as_a_list()
+        public void It_gets_XmlNode_single_child_element_value_as_a_string()
         {
             XmlDocument target = new XmlDocument();
             target.LoadXml("<doc attr='val'><child>text</child></doc>");
-            XmlNodeList elements = (XmlNodeList)ValueGetter.GetValue(target.DocumentElement, "child");
-            Assert.AreEqual(1, elements.Count);
-            Assert.AreEqual("text", elements[0].InnerText);
+            var value= (string)ValueGetter.GetValue(target.DocumentElement, "child");
+            Assert.AreEqual("text", value);
         }
 
         [Test]

--- a/Nustache.Core/RenderContext.cs
+++ b/Nustache.Core/RenderContext.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Xml;
 
 namespace Nustache.Core
 {
@@ -31,7 +32,12 @@ namespace Nustache.Core
         {
             if (path == ".")
             {
-                return _dataStack.Peek();
+                object peekedObject = _dataStack.Peek();
+                if (peekedObject as XmlElement != null)
+                {
+                    return ((XmlElement)peekedObject).InnerText;
+                }
+                return peekedObject;
             }
 
             foreach (var data in _dataStack)

--- a/Nustache.Core/ValueGetter.cs
+++ b/Nustache.Core/ValueGetter.cs
@@ -60,6 +60,8 @@ namespace Nustache.Core
 
         private readonly XmlNode _target;
         private readonly string _name;
+        private string _textValueLocated;
+        private XmlNodeList _childNodeList;
 
         private XmlNodeValueGetter(XmlNode target, string name)
         {
@@ -67,31 +69,64 @@ namespace Nustache.Core
             _name = name;
         }
 
+        private bool HasChildNodeList()
+        {
+            _childNodeList = _target.SelectNodes(_name);
+            return _childNodeList != null && _childNodeList.Count > 0;
+        }
+
+        private bool TryGetSingleTextNodeValue()
+        {
+            if (_childNodeList.Count != 1)
+                return false;
+
+            return TryGetNodeValueAsText(_childNodeList[0]);
+        }
+
+        private bool TryGetNodeValueAsText(XmlNode node)
+        {
+            if (node.ChildNodes.Count == 1
+                && node.ChildNodes[0].NodeType == XmlNodeType.Text)
+            {
+                _textValueLocated = node.ChildNodes[0].Value;
+                return true;
+            }
+            return false;
+        }
+
         public override object GetValue()
         {
-            if (_name[0] == '@')
-            {
-                if (_target.Attributes != null)
-                {
-                    XmlNode attribute = _target.Attributes.GetNamedItem(_name.Substring(1));
+            if (_name[0] == '@' && TryGetStringByAttributeName(_name.Substring(1)))
+                return _textValueLocated;
 
-                    if (attribute != null)
-                    {
-                        return attribute.Value;
-                    }
-                }
+            if (HasChildNodeList())
+            {
+                if (TryGetSingleTextNodeValue())
+                    return _textValueLocated;
+
+                return _childNodeList;
             }
-            else
-            {
-                XmlNodeList list = _target.SelectNodes(_name);
 
-                if (list != null && list.Count > 0)
-                {
-                    return list;
-                }
+            if (TryGetStringByAttributeName(_name))
+            {
+                return _textValueLocated;
             }
 
             return NoValue;
+        }
+
+        private bool TryGetStringByAttributeName(string attributeName)
+        {
+            if (_target.Attributes != null)
+            {
+                XmlNode attribute = _target.Attributes.GetNamedItem(attributeName);
+                if (attribute != null)
+                {
+                    _textValueLocated = attribute.Value;
+                    return true;
+                }
+            }
+            return false;
         }
     }
 


### PR DESCRIPTION
I noticed when i pulled down the project, built nustache.exe, and executed the test template against the test xml, the xml values were not substituted properly. I tried to improve this. Please let me know what you think and integrate if you'd like to. Thanks very much! More details below

Templating 

> nustache.exe test.nustache test.xml foo.txt

Output

> type foo.txt
> Hello
> You have just won $System.Xml.XPathNodeList!
> !!!

In my change
<x>
<d>a</d>
<d>b</d>
</x>

{{#d}}
{{.}}
{{/d}

would render     a  b

<x>
<c>text</c>
</x>

{{c}}

would render    text

And test template renders

Hello Chris
You have just won $10000!
Well, $9600, after taxes.
!!!
