### PR TITLE
Provided a hook for adding additional value getters.

### DIFF
--- a/Nustache.Core/Nustache.Core.csproj
+++ b/Nustache.Core/Nustache.Core.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TemplateInclude.cs" />
     <Compile Include="ValueGetter.cs" />
+    <Compile Include="ValueGetterFactory.cs" />
     <Compile Include="VariableReference.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Nustache.Core/ValueGetter.cs
+++ b/Nustache.Core/ValueGetter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
 using System.Xml;
@@ -15,19 +14,7 @@ namespace Nustache.Core
 
         public static object GetValue(object target, string name)
         {
-            return GetValueGetter(target, name).GetValue();
-        }
-
-        private static ValueGetter GetValueGetter(object target, string name)
-        {
-            return XmlNodeValueGetter.GetXmlNodeValueGetter(target, name)
-                ?? PropertyDescriptorValueGetter.GetPropertyDescriptorValueGetter(target, name)
-                ?? GenericDictionaryValueGetter.GetGenericDictionaryValueGetter(target, name)
-                ?? DictionaryValueGetter.GetDictionaryValueGetter(target, name)
-                ?? MethodInfoValueGetter.GetMethodInfoValueGetter(target, name)
-                ?? PropertyInfoValueGetter.GetPropertyInfoValueGetter(target, name)
-                ?? FieldInfoValueGetter.GetFieldInfoValueGetter(target, name)
-                ?? (ValueGetter)new NoValueGetter();
+            return ValueGetterFactories.Factories.GetValueGetter(target, name).GetValue();
         }
 
         #endregion
@@ -37,31 +24,14 @@ namespace Nustache.Core
         public abstract object GetValue();
 
         #endregion
-
-        #region Constants for derived classes that use reflection
-
-        protected const BindingFlags DefaultBindingFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase;
-        protected const StringComparison DefaultNameComparison = StringComparison.CurrentCultureIgnoreCase;
-
-        #endregion
     }
 
     internal class XmlNodeValueGetter : ValueGetter
     {
-        internal static XmlNodeValueGetter GetXmlNodeValueGetter(object target, string name)
-        {
-            if (target is XmlNode)
-            {
-                return new XmlNodeValueGetter((XmlNode)target, name);
-            }
-
-            return null;
-        }
-
         private readonly XmlNode _target;
         private readonly string _name;
 
-        private XmlNodeValueGetter(XmlNode target, string name)
+        internal XmlNodeValueGetter(XmlNode target, string name)
         {
             _target = target;
             _name = name;
@@ -97,29 +67,10 @@ namespace Nustache.Core
 
     internal class PropertyDescriptorValueGetter : ValueGetter
     {
-        internal static PropertyDescriptorValueGetter GetPropertyDescriptorValueGetter(object target, string name)
-        {
-            if (target is ICustomTypeDescriptor)
-            {
-                var typeDescriptor = (ICustomTypeDescriptor)target;
-                PropertyDescriptorCollection properties = typeDescriptor.GetProperties();
-
-                foreach (PropertyDescriptor property in properties)
-                {
-                    if (String.Equals(property.Name, name, DefaultNameComparison))
-                    {
-                        return new PropertyDescriptorValueGetter(target, property);
-                    }
-                }
-            }
-
-            return null;
-        }
-
         private readonly object _target;
         private readonly PropertyDescriptor _propertyDescriptor;
 
-        private PropertyDescriptorValueGetter(object target, PropertyDescriptor propertyDescriptor)
+        internal PropertyDescriptorValueGetter(object target, PropertyDescriptor propertyDescriptor)
         {
             _target = target;
             _propertyDescriptor = propertyDescriptor;
@@ -133,31 +84,10 @@ namespace Nustache.Core
 
     internal class MethodInfoValueGetter : ValueGetter
     {
-        internal static MethodInfoValueGetter GetMethodInfoValueGetter(object target, string name)
-        {
-            MemberInfo[] methods = target.GetType().GetMember(name, MemberTypes.Method, DefaultBindingFlags);
-
-            foreach (MethodInfo method in methods)
-            {
-                if (MethodCanGetValue(method))
-                {
-                    return new MethodInfoValueGetter(target, method);
-                }
-            }
-
-            return null;
-        }
-
-        private static bool MethodCanGetValue(MethodInfo method)
-        {
-            return method.ReturnType != typeof(void) &&
-                   method.GetParameters().Length == 0;
-        }
-
         private readonly object _target;
         private readonly MethodInfo _methodInfo;
 
-        private MethodInfoValueGetter(object target, MethodInfo methodInfo)
+        internal MethodInfoValueGetter(object target, MethodInfo methodInfo)
         {
             _target = target;
             _methodInfo = methodInfo;
@@ -171,27 +101,10 @@ namespace Nustache.Core
 
     internal class PropertyInfoValueGetter : ValueGetter
     {
-        internal static PropertyInfoValueGetter GetPropertyInfoValueGetter(object target, string name)
-        {
-            PropertyInfo property = target.GetType().GetProperty(name, DefaultBindingFlags);
-
-            if (property != null && PropertyCanGetValue(property))
-            {
-                return new PropertyInfoValueGetter(target, property);
-            }
-
-            return null;
-        }
-
-        private static bool PropertyCanGetValue(PropertyInfo property)
-        {
-            return property.CanRead;
-        }
-
         private readonly object _target;
         private readonly PropertyInfo _propertyInfo;
 
-        private PropertyInfoValueGetter(object target, PropertyInfo propertyInfo)
+        internal PropertyInfoValueGetter(object target, PropertyInfo propertyInfo)
         {
             _target = target;
             _propertyInfo = propertyInfo;
@@ -205,22 +118,10 @@ namespace Nustache.Core
 
     internal class FieldInfoValueGetter : ValueGetter
     {
-        internal static FieldInfoValueGetter GetFieldInfoValueGetter(object target, string name)
-        {
-            FieldInfo field = target.GetType().GetField(name, DefaultBindingFlags);
-
-            if (field != null)
-            {
-                return new FieldInfoValueGetter(target, field);
-            }
-
-            return null;
-        }
-
         private readonly object _target;
         private readonly FieldInfo _fieldInfo;
 
-        private FieldInfoValueGetter(object target, FieldInfo fieldInfo)
+        internal FieldInfoValueGetter(object target, FieldInfo fieldInfo)
         {
             _target = target;
             _fieldInfo = fieldInfo;
@@ -234,25 +135,10 @@ namespace Nustache.Core
 
     internal class DictionaryValueGetter : ValueGetter
     {
-        internal static DictionaryValueGetter GetDictionaryValueGetter(object target, string name)
-        {
-            if (target is IDictionary)
-            {
-                var dictionary = (IDictionary)target;
-
-                if (dictionary.Contains(name))
-                {
-                    return new DictionaryValueGetter(dictionary, name);
-                }
-            }
-
-            return null;
-        }
-
         private readonly IDictionary _target;
         private readonly string _key;
 
-        private DictionaryValueGetter(IDictionary target, string key)
+        internal DictionaryValueGetter(IDictionary target, string key)
         {
             _target = target;
             _key = key;
@@ -266,40 +152,11 @@ namespace Nustache.Core
 
     internal class GenericDictionaryValueGetter : ValueGetter
     {
-        internal static GenericDictionaryValueGetter GetGenericDictionaryValueGetter(object target, string name)
-        {
-            Type dictionaryType = null;
-
-            foreach (var interfaceType in target.GetType().GetInterfaces())
-            {
-                if (interfaceType.IsGenericType &&
-                    interfaceType.GetGenericTypeDefinition() == typeof(IDictionary<,>) &&
-                    interfaceType.GetGenericArguments()[0] == typeof(string))
-                {
-                    dictionaryType = interfaceType;
-
-                    break;
-                }
-            }
-
-            if (dictionaryType != null)
-            {
-                var containsKeyMethod = dictionaryType.GetMethod("ContainsKey");
-
-                if ((bool)containsKeyMethod.Invoke(target, new object[] { name }))
-                {
-                    return new GenericDictionaryValueGetter(target, name, dictionaryType);
-                }
-            }
-
-            return null;
-        }
-
         private readonly object _target;
         private readonly string _key;
         private readonly MethodInfo _getMethod;
 
-        private GenericDictionaryValueGetter(object target, string key, Type dictionaryType)
+        internal GenericDictionaryValueGetter(object target, string key, Type dictionaryType)
         {
             _target = target;
             _key = key;

--- a/Nustache.Core/ValueGetterFactory.cs
+++ b/Nustache.Core/ValueGetterFactory.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Reflection;
+using System.Xml;
+
+namespace Nustache.Core
+{
+    public abstract class ValueGetterFactory
+    {
+        public abstract ValueGetter GetValueGetter(object target, string name);
+
+        protected const BindingFlags DefaultBindingFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase;
+        protected const StringComparison DefaultNameComparison = StringComparison.CurrentCultureIgnoreCase;
+    }
+
+    public class ValueGetterFactoryCollection : Collection<ValueGetterFactory>
+    {
+        protected override void InsertItem(int index, ValueGetterFactory item)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException("item");
+            }
+
+            base.InsertItem(index, item);
+        }
+
+        protected override void SetItem(int index, ValueGetterFactory item)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException("item");
+            }
+
+            base.SetItem(index, item);
+        }
+
+        public ValueGetter GetValueGetter(object target, string name)
+        {
+            return GetValueGetterOrDefault(Items, target, name) ?? new NoValueGetter();
+        }
+
+        private static ValueGetter GetValueGetterOrDefault(IEnumerable<ValueGetterFactory> factories, object target, string name)
+        {
+            foreach (var factory in factories)
+            {
+                var getter = factory.GetValueGetter(target, name);
+                if (getter != null)
+                {
+                    return getter;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    public static class ValueGetterFactories
+    {
+        private static readonly ValueGetterFactoryCollection _factories = new ValueGetterFactoryCollection
+        {
+            new XmlNodeValueGetterFactory(),
+            new PropertyDescriptorValueGetterFactory(),
+            new GenericDictionaryValueGetterFactory(),
+            new DictionaryValueGetterFactory(),
+            new MethodInfoValueGatterFactory(),
+            new PropertyInfoValueGetterFactory(),
+            new FieldInfoValueGetterFactory()
+        };
+
+        public static ValueGetterFactoryCollection Factories
+        {
+            get { return _factories; }
+        }
+    }
+
+    internal class XmlNodeValueGetterFactory : ValueGetterFactory
+    {
+        public override ValueGetter GetValueGetter(object target, string name)
+        {
+            if (target is XmlNode)
+            {
+                return new XmlNodeValueGetter((XmlNode)target, name);
+            }
+
+            return null;
+        }
+    }
+
+    internal class PropertyDescriptorValueGetterFactory : ValueGetterFactory
+    {
+        public override ValueGetter GetValueGetter(object target, string name)
+        {
+            if (target is ICustomTypeDescriptor)
+            {
+                var typeDescriptor = (ICustomTypeDescriptor)target;
+                PropertyDescriptorCollection properties = typeDescriptor.GetProperties();
+
+                foreach (PropertyDescriptor property in properties)
+                {
+                    if (String.Equals(property.Name, name, DefaultNameComparison))
+                    {
+                        return new PropertyDescriptorValueGetter(target, property);
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+
+    internal class MethodInfoValueGatterFactory : ValueGetterFactory
+    {
+        public override ValueGetter GetValueGetter(object target, string name)
+        {
+            MemberInfo[] methods = target.GetType().GetMember(name, MemberTypes.Method, DefaultBindingFlags);
+
+            foreach (MethodInfo method in methods)
+            {
+                if (MethodCanGetValue(method))
+                {
+                    return new MethodInfoValueGetter(target, method);
+                }
+            }
+
+            return null;
+        }
+
+        private static bool MethodCanGetValue(MethodInfo method)
+        {
+            return method.ReturnType != typeof(void) &&
+                   method.GetParameters().Length == 0;
+        }
+    }
+
+    internal class PropertyInfoValueGetterFactory : ValueGetterFactory
+    {
+        public override ValueGetter GetValueGetter(object target, string name)
+        {
+            PropertyInfo property = target.GetType().GetProperty(name, DefaultBindingFlags);
+
+            if (property != null && PropertyCanGetValue(property))
+            {
+                return new PropertyInfoValueGetter(target, property);
+            }
+
+            return null;
+        }
+
+        private static bool PropertyCanGetValue(PropertyInfo property)
+        {
+            return property.CanRead;
+        }
+    }
+
+    internal class FieldInfoValueGetterFactory : ValueGetterFactory
+    {
+        public override ValueGetter GetValueGetter(object target, string name)
+        {
+            FieldInfo field = target.GetType().GetField(name, DefaultBindingFlags);
+
+            if (field != null)
+            {
+                return new FieldInfoValueGetter(target, field);
+            }
+
+            return null;
+        }
+    }
+
+    internal class DictionaryValueGetterFactory : ValueGetterFactory
+    {
+        public override ValueGetter GetValueGetter(object target, string name)
+        {
+            if (target is IDictionary)
+            {
+                var dictionary = (IDictionary)target;
+
+                if (dictionary.Contains(name))
+                {
+                    return new DictionaryValueGetter(dictionary, name);
+                }
+            }
+
+            return null;
+        }
+    }
+
+    internal class GenericDictionaryValueGetterFactory : ValueGetterFactory
+    {
+        public override ValueGetter GetValueGetter(object target, string name)
+        {
+            Type dictionaryType = null;
+
+            foreach (var interfaceType in target.GetType().GetInterfaces())
+            {
+                if (interfaceType.IsGenericType &&
+                    interfaceType.GetGenericTypeDefinition() == typeof(IDictionary<,>) &&
+                    interfaceType.GetGenericArguments()[0] == typeof(string))
+                {
+                    dictionaryType = interfaceType;
+
+                    break;
+                }
+            }
+
+            if (dictionaryType != null)
+            {
+                var containsKeyMethod = dictionaryType.GetMethod("ContainsKey");
+
+                if ((bool)containsKeyMethod.Invoke(target, new object[] { name }))
+                {
+                    return new GenericDictionaryValueGetter(target, name, dictionaryType);
+                }
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
I've added a hook for adding additional `ValueGetter`:s. I've extracted the static factory method for each `ValueGetter` to its own class which derives from `ValueGetterFactory` and added a global `ValueGetterFactories.Factories` class and property to which it is possible to add additional `ValueGetter`:s. 

This is the least intrusive approach I could think of and it mimics the approach used for `ValueProviderFactories` in ASP.NET MVC.

Originally I wanted to add support for dynamic objects, but since Nustache is compiled using the .NET 2.0 compiler and I didn't want to go down the route of adding support for multiple framework versions this was the compromise I decided on.

Using this approach I can add support for dynamic objects to my own code using a custom `ValueGetter` and `ValueGetterFactory`.

``` csharp
public class DynamicMetaObjectProviderValueGetter : ValueGetter
{
    private readonly IDynamicMetaObjectProvider target;
    private readonly string name;

    internal DynamicMetaObjectProviderValueGetter(IDynamicMetaObjectProvider target, string name)
    {
        this.target = target;
        this.name = name;
    }

    public override object GetValue()
    {
        var binder = Binder.GetMember(CSharpBinderFlags.None, name, target.GetType(), new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });

        var callsite = CallSite<Func<CallSite, object, object>>.Create(binder);
        return callsite.Target(callsite, target);
     }
}

public class DynamicMetaObjectProviderValueGetterFactory : ValueGetterFactory
{
    public override ValueGetter GetValueGetter(object target, string name)
    {
        var provider = target as IDynamicMetaObjectProvider;
        if (provider != null)
        {
            var members = provider.GetMetaObject(Expression.Constant(target)).GetDynamicMemberNames();
            string result = members.FirstOrDefault(x => string.Equals(x, name, DefaultNameComparison));

            if (result != null)
            {
                return new DynamicMetaObjectProviderValueGetter(provider, result);
            }
        }

        return null;
    }
}
```

The following tests should now pass.

``` csharp
[TestFixture]
public class DynamicMetaObjectProviderValueGetterTests 
{
    public class ReadWriteDynamicObject : DynamicObject
    {
        private readonly Dictionary<string, object> obj = new Dictionary<string, object>();

        public override bool TryGetMember(GetMemberBinder binder, out object result)
        {
            return obj.TryGetValue(binder.Name, out result);
        }

        public override bool TrySetMember(SetMemberBinder binder, object value)
        {
            obj[binder.Name] = value;
            return true;
        }

        public override IEnumerable<string> GetDynamicMemberNames()
        {
            return obj.Keys;
        }
    }

    [TestFixtureSetUp]
    public void Context()
    {
        ValueGetterFactories.Factories.Add(new DynamicMetaObjectProviderValueGetterFactory());
    }

    [Test]
    public void It_gets_dynamic_members()
    {
        dynamic target = new ReadWriteDynamicObject();
        target.DynamicMember = 123;

        Assert.AreEqual(123, ValueGetter.GetValue(target, "DynamicMember"));
    }

    [Test]
    public void It_gets_case_insensitive_dynamic_members()
    {
        dynamic target = new ReadWriteDynamicObject();
        target.DynamicMember = 123;

        Assert.AreEqual(123, ValueGetter.GetValue(target, "dynamicMember"));
    }
}
```
