### PR TITLE
Trim extraneous spaces in template includes

### DIFF
--- a/Nustache.Core.Tests/Describe_TemplateInclude.cs
+++ b/Nustache.Core.Tests/Describe_TemplateInclude.cs
@@ -34,5 +34,12 @@ namespace Nustache.Core.Tests
 
             Assert.AreEqual("TemplateInclude(\"a\")", a.ToString());
         }
+
+        [Test]
+        public void It_trims_spaces()
+        {
+            var a = new TemplateInclude(" a ");
+            Assert.AreEqual(a.Name, "a");
+        }
     }
 }

--- a/Nustache.Core/TemplateInclude.cs
+++ b/Nustache.Core/TemplateInclude.cs
@@ -13,7 +13,7 @@ namespace Nustache.Core
                 throw new ArgumentNullException("name");
             }
 
-            _name = name;
+            _name = name.Trim();
         }
 
         public string Name { get { return _name; } }


### PR DESCRIPTION
We have a design tech who likes to use spaces in Mustache templates.  For example, {{_foo_}}).  For variable getters, they work just fine.  However, I ran into trouble when he did a template include (e.g. {{>_foo_}}).  I got an asp.net exception that it couldn't find a template because it was looking for _foo_.mustache.
