### PR TITLE
Enhance method invoking(pass a render context parameter), can get the binding object by the parameter.

### DIFF
--- a/Nustache.Core.Tests/Describe_Method.cs
+++ b/Nustache.Core.Tests/Describe_Method.cs
@@ -1,0 +1,49 @@
+﻿using NUnit.Framework;
+
+namespace Nustache.Core.Tests
+{
+    [TestFixture]
+    public class Describe_Method
+    {
+        [Test]
+        public void It_can_render_method_result()
+        {
+            var result = Render.StringToString("{{#Rows}}{{#Columns}}{{GetValue}}{{/Columns}}{{/Rows}}", GetTableData());
+            Assert.AreEqual("tttttt", result);
+        }
+                
+        [Test]
+        public void It_can_render_method_result_with_context()
+        {
+            var result = Render.StringToString("{{#Rows}}{{#Columns}}{{GetValueWithContext}}{{/Columns}}{{/Rows}}", GetTableData());
+            Assert.AreEqual("123246", result);
+        }
+                
+        private static TableData GetTableData()
+        {
+            return new TableData()
+            {
+                Rows = new int[] { 1, 2 },
+                Columns = new int[] { 1, 2, 3 },
+            };
+        }
+    }
+
+    class TableData
+    {
+        public int[] Rows { get; set; }
+        public int[] Columns { get; set; }
+
+        public string GetValue()
+        {
+            return "t";
+        }
+
+        public string GetValueWithContext(RenderContext renderContext)
+        {
+            int row = (int)renderContext.GetSectionData("Rows");
+            int column = (int)renderContext.GetSectionData("Columns");
+            return (row * column).ToString();
+        }
+    }
+}

--- a/Nustache.Core.Tests/Describe_ValueGetter.cs
+++ b/Nustache.Core.Tests/Describe_ValueGetter.cs
@@ -13,7 +13,7 @@ namespace Nustache.Core.Tests
         [Test]
         public void It_returns_NoValue_when_it_cant_get_a_value()
         {
-            Assert.AreSame(ValueGetter.NoValue, ValueGetter.GetValue(this, "x"));
+            Assert.AreSame(ValueGetter.NoValue, ValueGetter.GetValue(this, "x", null));
         }
 
         [Test]
@@ -21,7 +21,7 @@ namespace Nustache.Core.Tests
         {
             ReadWriteInts target = new ReadWriteInts();
             target.IntField = 123;
-            Assert.AreEqual(123, ValueGetter.GetValue(target, "IntField"));
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "IntField", null));
         }
 
         [Test]
@@ -29,7 +29,7 @@ namespace Nustache.Core.Tests
         {
             ReadWriteInts target = new ReadWriteInts();
             target.IntField = 123;
-            Assert.AreEqual(123, ValueGetter.GetValue(target, "intfield"));
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "intfield", null));
         }
 
         [Test]
@@ -37,7 +37,7 @@ namespace Nustache.Core.Tests
         {
             ReadWriteInts target = new ReadWriteInts();
             target.IntField = 123;
-            Assert.AreEqual(123, ValueGetter.GetValue(target, "IntProperty"));
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "IntProperty", null));
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace Nustache.Core.Tests
         {
             ReadWriteInts target = new ReadWriteInts();
             target.IntField = 123;
-            Assert.AreEqual(123, ValueGetter.GetValue(target, "intproperty"));
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "intproperty", null));
         }
 
         [Test]
@@ -53,7 +53,15 @@ namespace Nustache.Core.Tests
         {
             ReadWriteInts target = new ReadWriteInts();
             target.IntField = 123;
-            Assert.AreEqual(123, ValueGetter.GetValue(target, "IntMethod"));
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "IntMethod", null));
+        }
+
+        [Test]
+        public void It_gets_method_context_values()
+        {
+            ReadWriteInts target = new ReadWriteInts();
+            target.IntField = 123;
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "IntMethodWithContext", null));
         }
 
         [Test]
@@ -61,21 +69,21 @@ namespace Nustache.Core.Tests
         {
             ReadWriteInts target = new ReadWriteInts();
             target.IntField = 123;
-            Assert.AreEqual(123, ValueGetter.GetValue(target, "intmethod"));
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "intmethod", null));
         }
 
         [Test]
         public void It_cant_get_values_from_write_only_properties()
         {
             WriteOnlyInts target = new WriteOnlyInts();
-            Assert.AreSame(ValueGetter.NoValue, ValueGetter.GetValue(target, "IntProperty"));
+            Assert.AreSame(ValueGetter.NoValue, ValueGetter.GetValue(target, "IntProperty", null));
         }
 
         [Test]
         public void It_cant_get_values_from_write_only_methods()
         {
             WriteOnlyInts target = new WriteOnlyInts();
-            Assert.AreSame(ValueGetter.NoValue, ValueGetter.GetValue(target, "IntMethod"));
+            Assert.AreSame(ValueGetter.NoValue, ValueGetter.GetValue(target, "IntMethod", null));
         }
 
         [Test]
@@ -83,7 +91,7 @@ namespace Nustache.Core.Tests
         {
             Hashtable target = new Hashtable();
             target["IntKey"] = 123;
-            Assert.AreEqual(123, ValueGetter.GetValue(target, "IntKey"));
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "IntKey", null));
         }
 
         [Test]
@@ -91,7 +99,7 @@ namespace Nustache.Core.Tests
         {
             Dictionary<string, int> target = new Dictionary<string, int>();
             target["IntKey"] = 123;
-            Assert.AreEqual(123, ValueGetter.GetValue(target, "IntKey"));
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "IntKey", null));
         }
 
         [Test]
@@ -101,7 +109,7 @@ namespace Nustache.Core.Tests
             mock.Setup(x => x.ContainsKey("Key")).Returns(true);
             mock.Setup(x => x["Key"]).Returns(123);
             IDictionary<string, int> target = mock.Object;
-            Assert.AreEqual(123, ValueGetter.GetValue(target, "Key"));
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "Key", null));
         }
 
         [Test]
@@ -111,7 +119,7 @@ namespace Nustache.Core.Tests
             dt.Columns.Add("IntColumn", typeof(int));
             dt.Rows.Add(new object[] { 123 });
             DataRowView target = dt.DefaultView[0];
-            Assert.AreEqual(123, ValueGetter.GetValue(target, "IntColumn"));
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "IntColumn", null));
         }
 
         [Test]
@@ -121,7 +129,7 @@ namespace Nustache.Core.Tests
             dt.Columns.Add("IntColumn", typeof(int));
             dt.Rows.Add(new object[] { 123 });
             DataRowView target = dt.DefaultView[0];
-            Assert.AreEqual(123, ValueGetter.GetValue(target, "intcolumn"));
+            Assert.AreEqual(123, ValueGetter.GetValue(target, "intcolumn", null));
         }
 
         [Test]
@@ -129,7 +137,7 @@ namespace Nustache.Core.Tests
         {
             XmlDocument target = new XmlDocument();
             target.LoadXml("<doc attr='val'></doc>");
-            Assert.AreEqual("val", ValueGetter.GetValue(target.DocumentElement, "@attr"));
+            Assert.AreEqual("val", ValueGetter.GetValue(target.DocumentElement, "@attr", null));
         }
 
         [Test]
@@ -137,7 +145,7 @@ namespace Nustache.Core.Tests
         {
             XmlDocument target = new XmlDocument();
             target.LoadXml("<doc attr='val'><child>text</child></doc>");
-            var value= (string)ValueGetter.GetValue(target.DocumentElement, "child");
+            var value = (string)ValueGetter.GetValue(target.DocumentElement, "child", null);
             Assert.AreEqual("text", value);
         }
 
@@ -146,7 +154,7 @@ namespace Nustache.Core.Tests
         {
             XmlDocument target = new XmlDocument();
             target.LoadXml("<doc attr='val'><child>text1</child><child>text2</child></doc>");
-            XmlNodeList elements = (XmlNodeList)ValueGetter.GetValue(target.DocumentElement, "child");
+            XmlNodeList elements = (XmlNodeList)ValueGetter.GetValue(target.DocumentElement, "child", null);
             Assert.AreEqual(2, elements.Count);
             Assert.AreEqual("text1", elements[0].InnerText);
             Assert.AreEqual("text2", elements[1].InnerText);
@@ -157,6 +165,7 @@ namespace Nustache.Core.Tests
             public int IntField = -1;
             public int IntProperty { get { return IntField; } set { IntField = value; } }
             public int IntMethod() { return IntField; }
+            public int IntMethodWithContext(RenderContext renderContext) { return IntField; }
             public void IntMethod(int value) { IntField = value; }
         }
 

--- a/Nustache.Core.Tests/Nustache.Core.Tests.csproj
+++ b/Nustache.Core.Tests/Nustache.Core.Tests.csproj
@@ -54,6 +54,7 @@
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Describe_Method.cs" />
     <Compile Include="Example_Trees.cs" />
     <Compile Include="Describe_Encoders.cs" />
     <Compile Include="Describe_Lambda.cs" />

--- a/Nustache.Core/ClassDiagram1.cd
+++ b/Nustache.Core/ClassDiagram1.cd
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ClassDiagram MajorVersion="1" MinorVersion="1">
+  <Class Name="Nustache.Core.Block" Collapsed="true">
+    <Position X="2.75" Y="3" Width="1.5" />
+    <Compartments>
+      <Compartment Name="Methods" Collapsed="true" />
+    </Compartments>
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAABAAAAAAAAA=</HashCode>
+      <FileName>Block.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Nustache.Core.Section" Collapsed="true">
+    <Position X="3" Y="1.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAIAoAAAIgAAAAwAABAAAAQAEAAAABAAABAAAAAAAAA=</HashCode>
+      <FileName>Section.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Nustache.Core.RenderContext">
+    <Position X="10" Y="2.75" Width="2.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAYAAAIAAgAIAACAAAUACAABIAAAAAAAEACIA=</HashCode>
+      <FileName>RenderContext.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Nustache.Core.Part" Collapsed="true">
+    <Position X="6.5" Y="0.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAA=</HashCode>
+      <FileName>Part.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Nustache.Core.InvertedBlock" Collapsed="true">
+    <Position X="4.5" Y="3" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAABAAAAAAAAA=</HashCode>
+      <FileName>InvertedBlock.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Nustache.Core.Template" Collapsed="true">
+    <Position X="1" Y="3" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAA=</HashCode>
+      <FileName>Template.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Nustache.Core.TemplateDefinition" Collapsed="true">
+    <Position X="0.75" Y="4.5" Width="2" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>TemplateDefinition.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Nustache.Core.EndSection" Collapsed="true">
+    <Position X="4.75" Y="1.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAIAAAAgAAAAAEAAAAAAQAAAAAAAAAABAAAAAAAAA=</HashCode>
+      <FileName>EndSection.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Nustache.Core.LiteralText" Collapsed="true">
+    <Position X="6.5" Y="1.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAgAAAAAEAAAAAAAAAAAAAAAIABAACAAAAAA=</HashCode>
+      <FileName>LiteralText.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Nustache.Core.TemplateInclude" Collapsed="true">
+    <Position X="8.25" Y="1.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAIAAAAgAAAAAEAAAAAAQAAAAAAAAAABAAAAAAAAA=</HashCode>
+      <FileName>TemplateInclude.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="Nustache.Core.VariableReference" Collapsed="true">
+    <Position X="10" Y="1.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAIgACAAIEAAAAAAAAAAAAAAAAABAAAAAAAAA=</HashCode>
+      <FileName>VariableReference.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Delegate Name="Nustache.Core.TemplateLocator" Collapsed="true">
+    <Position X="8" Y="4.75" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>RenderContext.cs</FileName>
+    </TypeIdentifier>
+  </Delegate>
+  <Delegate Name="Nustache.Core.Lambda" Collapsed="true">
+    <Position X="8" Y="3.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>RenderContext.cs</FileName>
+    </TypeIdentifier>
+  </Delegate>
+  <Font Name="微软雅黑" Size="9" />
+</ClassDiagram>

--- a/Nustache.Core/Nustache.Core.csproj
+++ b/Nustache.Core/Nustache.Core.csproj
@@ -87,6 +87,7 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <None Include="ClassDiagram1.cd" />
     <None Include="Nustache.Core.nuspec" />
     <None Include="Nustache.snk" />
   </ItemGroup>

--- a/Nustache.Core/Section.cs
+++ b/Nustache.Core/Section.cs
@@ -26,6 +26,15 @@ namespace Nustache.Core
             get { return _name; }
         }
 
+        /// <summary>
+        /// the binding data for the section.
+        /// </summary>
+        public object Data 
+        { 
+            get; 
+            set; 
+        }
+
         public IEnumerable<Part> Parts { get { return _parts; } }
 
         public void Load(IEnumerable<Part> parts)

--- a/Nustache.Core/ValueGetterFactory.cs
+++ b/Nustache.Core/ValueGetterFactory.cs
@@ -122,7 +122,15 @@ namespace Nustache.Core
             {
                 if (MethodCanGetValue(method))
                 {
-                    return new MethodInfoValueGetter(target, method);
+                    var parameters = method.GetParameters();
+                    if (parameters.Length == 0)
+                    {
+                        return new MethodInfoValueGetter(target, method, false);
+                    }
+                    else if (parameters.Length == 1 && parameters[0].ParameterType == typeof(RenderContext))
+                    {
+                        return new MethodInfoValueGetter(target, method, true);
+                    }
                 }
             }
 
@@ -131,8 +139,7 @@ namespace Nustache.Core
 
         private static bool MethodCanGetValue(MethodInfo method)
         {
-            return method.ReturnType != typeof(void) &&
-                   method.GetParameters().Length == 0;
+            return method.ReturnType != typeof(void);
         }
     }
 


### PR DESCRIPTION
[Test]
+        public void It_can_render_method_result_with_context()
+        {
+            var result = Render.StringToString("{{#Rows}}{{#Columns}}{{GetValueWithContext}}{{/Columns}}{/Rows}}", GetTableData());
+            Assert.AreEqual("123246", result);
+        }

//add RenderContext param support 
public string GetValueWithContext(RenderContext renderContext)
+        {
+            int row = (int)renderContext.GetSectionData("Rows");
+            int column = (int)renderContext.GetSectionData("Columns");
+            return (row * column).ToString();
+        }

//RenderContext add public method, and make other method internal.
+        public object GetSectionData(string sectionName)
+        {
+            foreach (var item in this._sectionStack)
+            {
+                if (string.Equals(item.Name, sectionName, StringComparison.CurrentCultureIgnoreCase))
+                {
+                    return item.Data;
+                }
+            }
+            return null;
         }

//valueGetter.GetValue add a RenderContext param.
+        public abstract object GetValue(RenderContext renderContext);