### PR TITLE
Added a facility to catch certain data inconsistencies at runtime.

### DIFF
--- a/Nustache.Core.Tests/Nustache.Core.Tests.csproj
+++ b/Nustache.Core.Tests/Nustache.Core.Tests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="PartComparer.cs" />
     <Compile Include="EnumerablePartExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RenderContext_Behaviour_Support.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nustache.Core\Nustache.Core.csproj">

--- a/Nustache.Core.Tests/RenderContext_Behaviour_Support.cs
+++ b/Nustache.Core.Tests/RenderContext_Behaviour_Support.cs
@@ -1,0 +1,59 @@
+﻿using NUnit.Framework;
+
+namespace Nustache.Core.Tests
+{
+    [TestFixture]
+    public class RenderContext_Behaviour_Support
+    {
+        [Test, ExpectedException(ExpectedException = typeof(NustacheDataContextMissException),
+            ExpectedMessage = "Path : . is undefined, RaiseExceptionOnDataContextMiss : true.")]
+        public void It_throws_an_exception_when_array_is_null_and_the_render_context_behaviour_throw_on_miss_is_true()
+        {
+            Render.StringToString("before{{#.}}{{.}}{{/.}}after", null , new RenderContextBehaviour{ RaiseExceptionOnDataContextMiss = true});
+        }
+
+        [Test, ExpectedException(ExpectedException = typeof(NustacheEmptyStringException),
+        ExpectedMessage = "Path : foo is an empty string, RaiseExceptionOnEmptyStringValue : true.")]
+        public void It_throws_an_exception_when_the_data_is_an_empty_string_and_the_render_context_behaviour_throw_on_empty_string_is_true()
+        {
+            Render.StringToString("before{{foo}}after", new{ foo = string.Empty}, new RenderContextBehaviour { RaiseExceptionOnEmptyStringValue = true });
+        }
+
+        [Test, ExpectedException(ExpectedException = typeof(NustacheDataContextMissException),
+        ExpectedMessage = "Path : foo is undefined, RaiseExceptionOnDataContextMiss : true.")]
+        public void It_throws_an_exception_when_there_is_no_data_and_the_render_context_behaviour_throw_on_miss_is_true()
+        {
+            Render.StringToString("before{{foo}}after", null, new RenderContextBehaviour { RaiseExceptionOnDataContextMiss = true });
+        }
+
+        [Test, ExpectedException(ExpectedException = typeof(NustacheDataContextMissException),
+            ExpectedMessage = "Path : foo.bar is undefined, RaiseExceptionOnDataContextMiss : true.")]
+        public void It_throws_an_exception_when_there_is_no_nested_data_and_the_render_context_behaviour_throw_on_miss_is_true()
+        {
+            Render.StringToString("before{{foo.bar}}after", new { foo = new { } }, new RenderContextBehaviour { RaiseExceptionOnDataContextMiss = true });
+        }
+
+        [Test, ExpectedException(ExpectedException = typeof(NustacheEmptyStringException),
+            ExpectedMessage = "Path : foo is an empty string, RaiseExceptionOnEmptyStringValue : true.")]
+        public void It_throws_an_exception_when_section_is_mapped_to_empty_string_and_the_render_context_behaviour_throw_on_empty_string_is_true()
+        {
+            Render.StringToString("before{{#foo}}FOO{{/foo}}after", new { foo = string.Empty }, new RenderContextBehaviour { RaiseExceptionOnEmptyStringValue = true });
+        }
+
+        [Test, ExpectedException(ExpectedException = typeof(NustacheDataContextMissException),
+            ExpectedMessage = "Path : foo is undefined, RaiseExceptionOnDataContextMiss : true.")]
+        public void It_throws_an_exception_when_section_is_mapped_to_null_and_the_render_context_behaviour_throw_on_miss_is_true()
+        {
+            Render.StringToString("before{{#foo}}FOO{{/foo}}after", new { foo = (string)null }, new RenderContextBehaviour { RaiseExceptionOnDataContextMiss = true });
+        }
+
+        [Test]
+        public void It_does_not_throw_an_exception_when_there_is_no_data_and_the_render_context_behaviour_throw_on_miss_is_false()
+        {
+            var result = Render.StringToString("before{{foo}}after", null, new RenderContextBehaviour { RaiseExceptionOnDataContextMiss = false });
+            Assert.AreEqual("beforeafter", result);
+        }
+
+
+    }
+}

--- a/Nustache.Core/Nustache.Core.csproj
+++ b/Nustache.Core/Nustache.Core.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Nustache.Core</RootNamespace>
     <AssemblyName>Nustache.Core</AssemblyName>
-    <TargetFrameworkVersion >v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -67,7 +67,10 @@
     <Compile Include="Encoders.cs" />
     <Compile Include="FileSystemTemplateLocator.cs" />
     <Compile Include="GenericDictionaryUtil.cs" />
+    <Compile Include="NustacheDataContextMissException.cs" />
+    <Compile Include="NustacheEmptyStringException.cs" />
     <Compile Include="PartVisitor.cs" />
+    <Compile Include="RenderContextBehaviour.cs" />
     <Compile Include="Section.cs" />
     <Compile Include="TemplateDefinition.cs" />
     <Compile Include="Render.cs" />

--- a/Nustache.Core/NustacheDataContextMissException.cs
+++ b/Nustache.Core/NustacheDataContextMissException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Nustache.Core
+{
+    [Serializable]
+    public class NustacheDataContextMissException : NustacheException
+    {
+        public NustacheDataContextMissException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/Nustache.Core/NustacheEmptyStringException.cs
+++ b/Nustache.Core/NustacheEmptyStringException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Nustache.Core
+{
+    [Serializable]
+    public class NustacheEmptyStringException : NustacheException
+    {
+        public NustacheEmptyStringException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/Nustache.Core/NustacheException.cs
+++ b/Nustache.Core/NustacheException.cs
@@ -1,28 +1,13 @@
 ﻿using System;
-//using System.Runtime.Serialization;
 
 namespace Nustache.Core
 {
     [Serializable]
     public class NustacheException : Exception
     {
-        //public NustacheException()
-        //{
-        //}
-
         public NustacheException(string message)
             : base(message)
         {
         }
-
-        //public NustacheException(string message, Exception inner)
-        //    : base(message, inner)
-        //{
-        //}
-
-        //protected NustacheException(SerializationInfo info, StreamingContext context)
-        //    : base(info, context)
-        //{
-        //}
     }
 }

--- a/Nustache.Core/Render.cs
+++ b/Nustache.Core/Render.cs
@@ -4,60 +4,89 @@ namespace Nustache.Core
 {
     public static class Render
     {
-        public static string StringToString(string template, object data)
+        public static string StringToString(string template, object data, RenderContextBehaviour renderContextBehaviour = null)
         {
-            return StringToString(template, data, null);
+            var renderBehaviour = renderContextBehaviour ??
+                                         RenderContextBehaviour.GetDefaultRenderContextBehaviour();
+
+            return StringToString(template, data, null, renderBehaviour);
         }
 
-        public static string StringToString(string template, object data, TemplateLocator templateLocator)
+        public static string StringToString(string template, object data, TemplateLocator templateLocator, RenderContextBehaviour renderContextBehaviour = null)
         {
             var reader = new StringReader(template);
             var writer = new StringWriter();
-            Template(reader, data, writer, templateLocator);
+
+            var renderBehaviour = renderContextBehaviour ??
+                                         RenderContextBehaviour.GetDefaultRenderContextBehaviour();
+
+            Template(reader, data, writer, templateLocator, renderBehaviour);
             return writer.GetStringBuilder().ToString();
         }
 
-        public static string FileToString(string templatePath, object data)
+        public static string FileToString(string templatePath, object data, RenderContextBehaviour renderContextBehaviour = null)
         {
             var template = File.ReadAllText(templatePath);
             var templateLocator = GetTemplateLocator(templatePath);
-            return StringToString(template, data, templateLocator.GetTemplate);
+
+            var renderBehaviour = renderContextBehaviour ??
+                                         RenderContextBehaviour.GetDefaultRenderContextBehaviour();
+
+            return StringToString(template, data, templateLocator.GetTemplate, renderBehaviour);
         }
 
-        public static void StringToFile(string template, object data, string outputPath)
+        public static void StringToFile(string template, object data, string outputPath, RenderContextBehaviour renderContextBehaviour = null)
         {
-            StringToFile(template, data, outputPath, null);
+            var renderBehaviour = renderContextBehaviour ??
+                                         RenderContextBehaviour.GetDefaultRenderContextBehaviour();
+
+            StringToFile(template, data, outputPath, null, renderBehaviour);
         }
 
-        public static void StringToFile(string template, object data, string outputPath, TemplateLocator templateLocator)
+        public static void StringToFile(string template, object data, string outputPath, TemplateLocator templateLocator, RenderContextBehaviour renderContextBehaviour = null)
         {
             var reader = new StringReader(template);
+
+            var renderBehaviour = renderContextBehaviour ??
+                                        RenderContextBehaviour.GetDefaultRenderContextBehaviour();
+
             using (var writer = File.CreateText(outputPath))
             {
-                Template(reader, data, writer, templateLocator);
+                Template(reader, data, writer, templateLocator, renderBehaviour);
             }
         }
 
-        public static void FileToFile(string templatePath, object data, string outputPath)
+        public static void FileToFile(string templatePath, object data, string outputPath, RenderContextBehaviour renderContextBehaviour = null)
         {
             var reader = new StringReader(File.ReadAllText(templatePath));
             var templateLocator = GetTemplateLocator(templatePath);
+
+            var renderBehaviour = renderContextBehaviour ??
+                                        RenderContextBehaviour.GetDefaultRenderContextBehaviour();
+
             using (var writer = File.CreateText(outputPath))
             {
-                Template(reader, data, writer, templateLocator.GetTemplate);
+                Template(reader, data, writer, templateLocator.GetTemplate, renderBehaviour);
             }
         }
 
-        public static void Template(TextReader reader, object data, TextWriter writer)
+        public static void Template(TextReader reader, object data, TextWriter writer, RenderContextBehaviour renderContextBehaviour = null)
         {
-            Template(reader, data, writer, null);
+            var renderBehaviour = renderContextBehaviour ??
+                                        RenderContextBehaviour.GetDefaultRenderContextBehaviour();
+
+            Template(reader, data, writer, null, renderBehaviour);
         }
 
-        public static void Template(TextReader reader, object data, TextWriter writer, TemplateLocator templateLocator)
+        public static void Template(TextReader reader, object data, TextWriter writer, TemplateLocator templateLocator, RenderContextBehaviour renderContextBehaviour = null)
         {
             var template = new Template();
             template.Load(reader);
-            template.Render(data, writer, templateLocator);
+
+            var renderBehaviour = renderContextBehaviour ??
+                                        RenderContextBehaviour.GetDefaultRenderContextBehaviour();
+
+            template.Render(data, writer, templateLocator, renderBehaviour);
         }
 
         private static FileSystemTemplateLocator GetTemplateLocator(string templatePath)

--- a/Nustache.Core/RenderContextBehaviour.cs
+++ b/Nustache.Core/RenderContextBehaviour.cs
@@ -1,0 +1,18 @@
+﻿
+namespace Nustache.Core
+{
+    public class RenderContextBehaviour
+    {
+        public bool RaiseExceptionOnDataContextMiss { get; set; }
+        public bool RaiseExceptionOnEmptyStringValue { get; set; }
+
+        public static RenderContextBehaviour GetDefaultRenderContextBehaviour()
+        {
+            return new RenderContextBehaviour
+                        {
+                            RaiseExceptionOnDataContextMiss = false, 
+                            RaiseExceptionOnEmptyStringValue  = false
+                        }; 
+        }
+    }
+}

--- a/Nustache.Core/Template.cs
+++ b/Nustache.Core/Template.cs
@@ -102,11 +102,17 @@ namespace Nustache.Core
         /// </remarks>
         public void Render(object data, TextWriter writer, TemplateLocator templateLocator)
         {
-            var context = new RenderContext(this, data, writer, templateLocator);
+            Render(data, writer, templateLocator, RenderContextBehaviour.GetDefaultRenderContextBehaviour());
+        }
+
+        public void Render(object data, TextWriter writer, TemplateLocator templateLocator, RenderContextBehaviour renderContextBehaviour)
+        {
+            var context = new RenderContext(this, data, writer, templateLocator, renderContextBehaviour);
 
             Render(context);
 
             writer.Flush();
         }
+
     }
 }


### PR DESCRIPTION
Hey Jason,

Great project.

I was looking at the mustache documentation and came across a feature offered in the ruby implementation - namely to set an option to throw an exception of a missing data item during render.

For example rendering 

"{{foo.one}}  {{foo.two}}"

with the option enabled against the data

```
var dict = new Dictionary<string, object>();
dict.Add("one" , "Hello");
```

would fail explicitly rather than rendering "Hello " <--- it has dropped the {{foo.two}} placeholder.

I initially looked at the compile template awesomeness which looked like a great way to achieve something similar however it seems to require a concrete definition to compile against (which makes sense). In our system we don't have a statically defined representation of our data e.g. it's made out of Dictionaries, DataTables, dynamic proxies etc. so we are unable to use this functionalilty as easily as we would like it. We were also wanting to specify other behavior e.g. guard against strings being empty.

However taking inspiration from the ruby implementation what I have come up with is something that looks like this -

```
var dict = new Dictionary<string, object>();
dict.Add("one" , "Hello");
dict.Add("two" , true);

var behavior =  new RenderContextBehaviour() {
        RaiseExceptionOnDataContextMiss = true,  
        RaiseExceptionOnEmptyStringValue = true };

var ok = Render.StringToString("{{foo.one}}  {{foo.two}}", new{ foo = dict }, behavior );

//throws NustacheContextMissException
var fails = Render.StringToString("{{foo.DOES_NOT_EXIST}}  {{foo.two}}", new{ foo = dict }, behavior );

//change the dictionary value
dict["one"] = string.Empty ;

//throws NustacheEmptyStringException  
var failsAsWell = Render.StringToString("{{foo.one}}  {{foo.two}}", new{ foo = dict }, behavior );

```

It's not as pretty as Ruby :-)

Obviously all of the existing Render methods work as before with out the overload.

The RenderContextBehaviour object has the following properties (but could be extended beyond quite easily with other oprions)

RaiseExceptionOnDataContextMiss  will throw when an item is null
RaiseExceptionOnEmptyStringValue  will throw when a string is not null but is empty

I have added some unit tests with examples and kept the original api intact.

It would be great if you could have a chance to feedback on the changes.

This pull request replace the earlier one and tidies up the commits.

Thanks,

Mark
