### PR TITLE
Prevent AmbiguousMatchException when an object has two properties with the same name

### DIFF
--- a/Nustache.Core/ValueGetterFactory.cs
+++ b/Nustache.Core/ValueGetterFactory.cs
@@ -160,7 +160,7 @@ namespace Nustache.Core
             PropertyInfo property = null;
             foreach (var p in targetType.GetProperties(DefaultBindingFlags))
             {
-                if (p.Name.Equals(name))
+                if (p.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
                 {
                     property = p;
                     break;

--- a/Nustache.Core/ValueGetterFactory.cs
+++ b/Nustache.Core/ValueGetterFactory.cs
@@ -157,7 +157,15 @@ namespace Nustache.Core
     {
         public override ValueGetter GetValueGetter(object target, Type targetType, string name)
         {
-            PropertyInfo property = targetType.GetProperty(name, DefaultBindingFlags);
+            PropertyInfo property = null;
+            foreach (var p in targetType.GetProperties(DefaultBindingFlags))
+            {
+                if (p.Name.Equals(name))
+                {
+                    property = p;
+                    break;
+                }
+            }
 
             if (property != null && PropertyCanGetValue(property))
             {


### PR DESCRIPTION
If an object has both generic and non-generic versions of the same property, they will have the same property name, causing an AmbiguousMatchException to be thrown during property look-up. To prevent this, I modified the PropertyInfoValueGetterFactory to iterate all properties matching the binding flags and to assign the first property that matches the specified name (in a case-insensitive manner).