### PR TITLE
Use assembly version for MVC3 nuget core dependency

### DIFF
--- a/Nustache.Mvc3/Nustache.Mvc3.nuspec
+++ b/Nustache.Mvc3/Nustache.Mvc3.nuspec
@@ -11,7 +11,7 @@
     <description>$description$</description>
     <tags>Template Mustache MVC</tags>
     <dependencies>
-      <dependency id="Nustache" version="1.12.2.12" />
+      <dependency id="Nustache" version="$version$" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
- The nuget package for Mvc3 currently depends on an old version of the core library.  Since the version numbers synchronised across the projects I've changed the nuspec to use the version replacement token.