### PR TITLE
Fixed bug in CompilePartVisitor not using Encoders.HtmlEncode

### DIFF
--- a/Nustache.Compilation.Tests/Nustache.Compilation.Tests.csproj
+++ b/Nustache.Compilation.Tests/Nustache.Compilation.Tests.csproj
@@ -33,6 +33,14 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.5.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="nunit.core">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
     </Reference>
@@ -51,6 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Compiled_Templates_Support.cs" />
+    <Compile Include="UseEncoderDelegate.cs" />
     <Compile Include="Describe_Compiled_Template_Data_Types.cs" />
     <Compile Include="Describe_Compound_Expression_Enumerator.cs" />
     <Compile Include="Mustache_Spec\examples\delimiters.cs" />

--- a/Nustache.Compilation.Tests/UseEncoderDelegate.cs
+++ b/Nustache.Compilation.Tests/UseEncoderDelegate.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using System.IO;
+using Nustache.Compilation;
+using Nustache.Core;
+
+namespace Nustache.Compilation.Tests
+{
+    [TestFixture]
+    public class Encoder_Delegate_Usage
+    {
+        class TemplateData
+        {
+            public string Value { get; set; }
+        }
+
+        [Test]
+        public void ReplacingHtmlEncodeWorksForCompiledTemplates()
+        {
+            // replace the default encoder with one that wraps the input in "--" 
+            Encoders.HtmlEncoder encoder = (input) => "--" + input + "--";
+            Encoders.HtmlEncode = encoder;
+
+            var template = Template("{{Value}}");
+            var compiled = template.Compile<TemplateData>(null);
+
+
+            var inputText = "Some cool text";
+            var data = new TemplateData()
+            {
+                Value = inputText
+            };
+
+            var expectedOutput = encoder(inputText);
+
+            Assert.AreEqual(expectedOutput, compiled(data));
+
+            // reset the used HTML encoder to default
+            Encoders.HtmlEncode = Encoders.DefaultHtmlEncode;
+        }
+
+        private Template Template(string text)
+        {
+            var template = new Template();
+            template.Load(new StringReader(text));
+            return template;
+        }
+    }
+}

--- a/Nustache.Compilation/CompilePartVisitor.cs
+++ b/Nustache.Compilation/CompilePartVisitor.cs
@@ -119,7 +119,9 @@ namespace Nustache.Compilation
 
             if (variable.Escaped)
             {
-                parts.Add(CompoundExpression.IndentOnLineEnd(Expression.Call(null, typeof(Encoders).GetMethod("DefaultHtmlEncode"), getter), context));
+                var escaperProperty = typeof(Encoders).GetProperty("HtmlEncode", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
+                var escaperMethod = (Delegate)escaperProperty.GetValue(null, null);
+                parts.Add(CompoundExpression.IndentOnLineEnd(Expression.Call(null, escaperMethod.Method, getter), context));
             }
             else
             {


### PR DESCRIPTION
This made it impossible to disable HTML escaping for compiled templates.

The fix itsel is in `Nustache.Compilation/CompilePartVisitor.cs`  where I modified the reflecting code to look up the `HtmlEncoder` delegate set.

Btw. this fixed most of Interpolation* test cases too (they run green after the patch - in my case at least)
