### PR TITLE
Allow using a different encoder each render

### DIFF
--- a/Nustache.Core.Tests/RenderContext_Behaviour_Support.cs
+++ b/Nustache.Core.Tests/RenderContext_Behaviour_Support.cs
@@ -54,6 +54,12 @@ namespace Nustache.Core.Tests
             Assert.AreEqual("beforeafter", result);
         }
 
-
+        [Test]
+        public void Use_custom_encoder()
+        {
+            var result = Render.StringToString("before{{foo}}after", new {foo = string.Empty},
+                new RenderContextBehaviour {HtmlEncoder = text => "middle"});
+            Assert.AreEqual("beforemiddleafter", result);
+        }
     }
 }

--- a/Nustache.Core/RenderContext.cs
+++ b/Nustache.Core/RenderContext.cs
@@ -30,6 +30,11 @@ namespace Nustache.Core
         public string ActiveStartDelimiter { get; set; }
         public string ActiveEndDelimiter { get; set; }
 
+        public Encoders.HtmlEncoder HtmlEncoder
+        {
+            get { return _renderContextBehaviour.HtmlEncoder ?? Encoders.HtmlEncode; }   
+        }
+
         public RenderContext(Section section, object data, TextWriter writer, TemplateLocator templateLocator, RenderContextBehaviour renderContextBehaviour = null) 
         {
             _sectionStack.Push(section);

--- a/Nustache.Core/RenderContextBehaviour.cs
+++ b/Nustache.Core/RenderContextBehaviour.cs
@@ -6,6 +6,8 @@ namespace Nustache.Core
         public bool RaiseExceptionOnDataContextMiss { get; set; }
         public bool RaiseExceptionOnEmptyStringValue { get; set; }
 
+        public Encoders.HtmlEncoder HtmlEncoder { get; set; }
+
         public static RenderContextBehaviour GetDefaultRenderContextBehaviour()
         {
             return new RenderContextBehaviour

--- a/Nustache.Core/VariableReference.cs
+++ b/Nustache.Core/VariableReference.cs
@@ -46,7 +46,7 @@ namespace Nustache.Core
                 var lambdaResult = lambda().ToString();
 
                 lambdaResult = _escaped
-                    ? Encoders.HtmlEncode(lambdaResult.ToString())
+                    ? context.HtmlEncoder(lambdaResult.ToString())
                     : lambdaResult.ToString(); 
 
                 using (System.IO.TextReader sr = new System.IO.StringReader(lambdaResult))
@@ -73,7 +73,7 @@ namespace Nustache.Core
             else if (value != null)
             {
                 context.Write(_escaped
-                    ? Encoders.HtmlEncode(value.ToString())
+                    ? context.HtmlEncoder(value.ToString())
                     : value.ToString());
             }
         }


### PR DESCRIPTION
Currently the static `Encoders` class allows changing the HTML encoder system-wide. This PR adds an option to `RenderContextBehaviour` that allows specifying a different encoder on each render.
