### PR TITLE
Add support for assembly in partial trust mode

### DIFF
--- a/Nustache.Core/Properties/AssemblyInfo.cs
+++ b/Nustache.Core/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -34,3 +35,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.14.0.0")]
 [assembly: AssemblyFileVersion("1.14.0.0")]
+
+[assembly: AllowPartiallyTrustedCallers()]


### PR DESCRIPTION
Allows the assembly to be used in SQLCLR for example.
- Add AllowPartialTrustedCallers assembly attribute
- Skip Getter Factories that error out because of partial trust
