### PR TITLE
Getter for XmlNodeList objects

### DIFF
--- a/Nustache.Core.Tests/Describe_ValueGetter.cs
+++ b/Nustache.Core.Tests/Describe_ValueGetter.cs
@@ -154,6 +154,45 @@ namespace Nustache.Core.Tests
         }
 
         [Test]
+        public void It_gets_single_string_values_as_string_by_Index_from_XmlNodeList()
+        {
+            XmlDocument target = new XmlDocument();
+            target.LoadXml(@"<doc attr='val'>
+    <child>text1</child>
+    <child>text2</child>
+    <child>text3</child>
+</doc>");
+            var value = (string)ValueGetter.GetValue(target.DocumentElement.ChildNodes, "1");
+            Assert.AreEqual("text2", value);
+        }
+
+        [Test]
+        public void It_gets_single_node_values_as_node_by_Index_from_XmlNodeList()
+        {
+            XmlDocument target = new XmlDocument();
+            target.LoadXml(@"<doc attr='val'>
+    <child>text1</child>
+    <child><grandchild>text2</grandchild></child>
+    <child>text3</child>
+</doc>");
+            var value = (XmlNode)ValueGetter.GetValue(target.DocumentElement.ChildNodes, "1");
+            Assert.AreEqual("<grandchild>text2</grandchild>", value.InnerXml);
+        }
+
+         [Test]
+        public void It_gets_single_CDATA_values_as_string_by_Index_from_XmlNodeList()
+        {
+            XmlDocument target = new XmlDocument();
+            target.LoadXml(@"<doc attr='val'>
+    <child><![CDATA[text1]]></child>
+    <child><![CDATA[text2]]></child>
+    <child><![CDATA[text3]]></child>
+</doc>");
+            var value = (string)ValueGetter.GetValue(target.DocumentElement.ChildNodes, "1");
+            Assert.AreEqual("text2", value);
+        }
+
+        [Test]
         public void It_gets_ListValueByIndex_values_from_array()
         {
             string[] target = new[] { "hello", "world" };

--- a/Nustache.Core/ValueGetter.cs
+++ b/Nustache.Core/ValueGetter.cs
@@ -122,6 +122,38 @@ namespace Nustache.Core
         }
     }
 
+    internal class XmlNodeListIndexGetter : ValueGetter
+    {
+        private readonly XmlNodeList _target;
+        private readonly int _index;
+        private object _foundSingleValue;
+
+        public XmlNodeListIndexGetter(XmlNodeList target, int index)
+        {
+            _target = target;
+            _index = index;
+        }
+
+        private object GetNodeValue(XmlNode node)
+        {
+            if (node.ChildNodes.Count == 1
+                && (node.ChildNodes[0].NodeType == XmlNodeType.Text || node.ChildNodes[0].NodeType == XmlNodeType.CDATA)
+            )
+            {
+                return node.ChildNodes[0].Value;
+            }
+            else
+            {
+                return node;
+            }
+        }
+
+        public override object GetValue()
+        {
+            return GetNodeValue(_target[_index]);
+        }
+    }
+
     internal class PropertyDescriptorValueGetter : ValueGetter
     {
         private readonly object _target;

--- a/Nustache.Core/ValueGetterFactory.cs
+++ b/Nustache.Core/ValueGetterFactory.cs
@@ -82,6 +82,7 @@ namespace Nustache.Core
         private static readonly ValueGetterFactoryCollection _factories = new ValueGetterFactoryCollection
         {
             new XmlNodeValueGetterFactory(),
+            new XmlNodeListIndexGetterFactory(),
             new PropertyDescriptorValueGetterFactory(),
             new GenericDictionaryValueGetterFactory(),
             new DataRowGetterFactory(),
@@ -106,6 +107,32 @@ namespace Nustache.Core
             if (target is XmlNode)
             {
                 return new XmlNodeValueGetter((XmlNode)target, name);
+            }
+
+            return null;
+        }
+    }
+
+    internal class XmlNodeListIndexGetterFactory : ValueGetterFactory
+    {
+        public override ValueGetter GetValueGetter(object target, Type targetType, string name)
+        {
+            if (target is XmlNodeList)
+            {
+                var listTarget = target as XmlNodeList;
+                int arrayIndex;
+                bool parseSuccess = Int32.TryParse(name, out arrayIndex);
+
+                /* 
+                 * There is an index as per the success of the parse, it is not greater than the count 
+                 * (minus one since index is zero referenced) or less than zero.
+                 */
+                if (parseSuccess &&
+                   !(arrayIndex > (listTarget.Count - 1)) &&
+                   !(arrayIndex < 0))
+                {
+                    return new XmlNodeListIndexGetter(listTarget, arrayIndex);
+                }
             }
 
             return null;


### PR DESCRIPTION
Lets you use {{foo.1}} to get the 2nd foo in

```
<foo>first</foo>
<foo>second</foo>
<foo>third</foo>
```

Redundant with XPath queries, but makes it consistent w other getter syntaxes.

- XmlNodeListGetter to pull from lists by index, similar to IList getter
- XmlNodeListGetterFactory to create above
- Tests for above.