### PR TITLE
Fix Expression generation in compilation

### DIFF
--- a/Nustache.Compilation.Tests/Compiled_Templates_Support.cs
+++ b/Nustache.Compilation.Tests/Compiled_Templates_Support.cs
@@ -25,6 +25,11 @@ namespace Nustache.Compilation.Tests
         public bool TestBool { get; set; }
 
         public SubObject Sub { get; set; }
+
+        public override string ToString()
+        {
+            return "SubObject";
+        }
     }
 
     [TestFixture]
@@ -271,6 +276,15 @@ namespace Nustache.Compilation.Tests
             var template = Template("A template with {{TestString1}} and {{TestBool}}");
             var compiled = template.Compile<TestObject>(null);
             compiled(new TestObject { TestString = "Hello", TestBool = true });
+        }
+
+        [Test]
+        public void Member_ToString()
+        {
+            var template = Template("A template with {{Sub}}");
+            var compiled = template.Compile<TestObject>(null);
+            var result = compiled(new TestObject { Sub = new SubObject() });
+            Assert.AreEqual("A template with SubObject", result);
         }
 
         private Func<T, string> Compiled<T>(string text) where T : class

--- a/Nustache.Compilation.Tests/Compiled_Templates_Support.cs
+++ b/Nustache.Compilation.Tests/Compiled_Templates_Support.cs
@@ -32,6 +32,15 @@ namespace Nustache.Compilation.Tests
         }
     }
 
+    public class TestObjectWithToString
+    {
+        public string TestString { get; set; }
+        public override string ToString()
+        {
+            return "";
+        }
+    }
+
     [TestFixture]
     public class Compiled_Templates_Support
     {
@@ -285,6 +294,15 @@ namespace Nustache.Compilation.Tests
             var compiled = template.Compile<TestObject>(null);
             var result = compiled(new TestObject { Sub = new SubObject() });
             Assert.AreEqual("A template with SubObject", result);
+        }
+
+        [Test]
+        public void Model_With_ToString()
+        {
+            var template = Template("A template with {{TestString}}");
+            var compiled = template.Compile<TestObjectWithToString>(null);
+            var result = compiled(new TestObjectWithToString { TestString = "Hello"});
+            Assert.AreEqual("A template with Hello", result);
         }
 
         private Func<T, string> Compiled<T>(string text) where T : class

--- a/Nustache.Compilation/CompilePartVisitor.cs
+++ b/Nustache.Compilation/CompilePartVisitor.cs
@@ -114,7 +114,7 @@ namespace Nustache.Compilation
         public void Visit(VariableReference variable)
         {
             var getter = context.CompiledGetter(variable.Path);
-            var returnIfNotNull = Expression.Call(getter, context.TargetType.GetMethod("ToString"));
+            var returnIfNotNull = Expression.Call(getter, getter.Type.GetMethod("ToString", new Type[0]));
             getter = CompoundExpression.NullCheck(getter, "", returnIfNotNull);
 
             if (variable.Escaped)

--- a/Nustache.Compilation/CompilePartVisitor.cs
+++ b/Nustache.Compilation/CompilePartVisitor.cs
@@ -114,8 +114,8 @@ namespace Nustache.Compilation
         public void Visit(VariableReference variable)
         {
             var getter = context.CompiledGetter(variable.Path);
-            getter = CompoundExpression.NullCheck(getter, "");
-            getter = Expression.Call(getter, context.TargetType.GetMethod("ToString"));
+            var returnIfNotNull = Expression.Call(getter, context.TargetType.GetMethod("ToString"));
+            getter = CompoundExpression.NullCheck(getter, "", returnIfNotNull);
 
             if (variable.Escaped)
             {


### PR DESCRIPTION
I've fixed two issues on Expression generation in compilation

- Variable access to reference types causes ArugmentException

    ```cs
    class Test {
        public object TestObject = new object();
    }
    var template = "Result is {{TestObject}}";
    ```
    throws `ArgumentException: Argument types do not match`.

- Model class which has ToString() method causes ArugmentException

    ```cs
    class Test {
        public string TestString = "Hello";
        public override string ToString() { return base.ToString(); }
    }
    var template = "Result is {{TestString}}";
    ```
    throws `ArgumentException: Method 'System.String ToString()' declared on type 'Test' cannot be called with instance of type 'System.String'`.

Also, I have added test cases for these situations.